### PR TITLE
Fix manual buy and add backend logging

### DIFF
--- a/BullishorBust/Backend/index.js
+++ b/BullishorBust/Backend/index.js
@@ -28,22 +28,15 @@ app.post('/trade', async (req, res) => {
 
 app.post('/buy', async (req, res) => {
   const { symbol, qty, side, type, time_in_force, limit_price } = req.body;
+  console.log('Received manual buy for:', symbol);
+  const order = { symbol, qty, side, type, time_in_force, limit_price };
+  console.log('Order payload:', order);
 
   try {
-    const response = await axios.post(
-      `${BASE_URL}/v2/orders`,
-      {
-        symbol,
-        qty,
-        side,
-        type,
-        time_in_force,
-        limit_price,
-      },
-      {
-        headers,
-      }
-    );
+    const response = await axios.post(`${BASE_URL}/v2/orders`, order, {
+      headers,
+    });
+    console.log('Alpaca response:', response.data);
     res.json(response.data);
   } catch (error) {
     console.error('Buy error:', error?.response?.data || error.message);


### PR DESCRIPTION
## Summary
- add backend URL config to frontend
- implement `manualBuy` and hook button
- log buy requests in frontend and backend

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688982479eb48325b92ae35b6ce66a76