### PR TITLE
Fix mobile backend access

### DIFF
--- a/BullishorBust/Backend/README.md
+++ b/BullishorBust/Backend/README.md
@@ -4,6 +4,8 @@ This Node.js backend handles Alpaca API trades via a `/buy` endpoint.
 
 ## Setup
 
+The server includes CORS support so it can be called from Expo Go.
+
 1. `npm install`
 2. Create a `.env` file with your Alpaca API keys.
 3. `npm start`

--- a/BullishorBust/Backend/index.js
+++ b/BullishorBust/Backend/index.js
@@ -1,10 +1,12 @@
 require('dotenv').config();
 const express = require('express');
+const cors = require('cors');
 const axios = require('axios');
 const { placeMarketBuyThenSell } = require('./trade');
 const app = express();
 app.use(express.json());
 
+app.use(cors());
 const API_KEY = process.env.ALPACA_API_KEY;
 const SECRET_KEY = process.env.ALPACA_SECRET_KEY;
 const BASE_URL = process.env.ALPACA_BASE_URL;

--- a/BullishorBust/Backend/package.json
+++ b/BullishorBust/Backend/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "axios": "^1.6.8",
+    "cors": "^2.8.5",
     "dotenv": "^16.0.3",
     "express": "^4.18.2"
   }

--- a/BullishorBust/Frontend/.env.example
+++ b/BullishorBust/Frontend/.env.example
@@ -1,4 +1,1 @@
-API_URL=https://paper-api.alpaca.markets/v2
-ALPACA_API_KEY=PKGY01ABISEXQJZX5L7M
-ALPACA_SECRET_KEY=PwJAEwLnLnsf7qAVvFutE8VIMgsAgvi7PMkMcCca
-ALPACA_BASE_URL=https://paper-api.alpaca.markets
+EXPO_PUBLIC_BACKEND_URL=http://192.168.1.100:3000

--- a/BullishorBust/Frontend/README.md
+++ b/BullishorBust/Frontend/README.md
@@ -5,8 +5,8 @@ Entry Logic
 Tokens are flagged ENTRY READY when the MACD line is above the signal line. If the MACD is rising but has not crossed, the token appears on the WATCHLIST. Other indicators are ignored for entry decisions.
 
 Setup
-npm install
-Copy .env.example to .env
-Start backend (Node.js Express server)
-Run: npm start (Expo)
+1. npm install
+2. Copy .env.example to .env and set `EXPO_PUBLIC_BACKEND_URL` to your local IP or tunnel URL
+3. Start backend (Node.js Express server)
+4. Run: npm start (Expo)
 The app shows temporary trade messages using a built-in overlay notification.


### PR DESCRIPTION
## Summary
- enable CORS in backend server
- document CORS in backend README
- add Expo backend URL env example
- update frontend README with env var instructions

## Testing
- `npm test` (fails: Missing script)
- `npm test` in Frontend (fails: Missing script)
- `npm install cors@^2.8.5 --save` (fails: 403 Forbidden due to offline environment)


------
https://chatgpt.com/codex/tasks/task_e_6889871a13a88325b82b75a564913a0f