### PR TITLE
Fix Render rootDir and Node version

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -6,4 +6,4 @@ services:
     plan: free
     buildCommand: npm install
     startCommand: npm start
-    nodeVersion: 18
+    nodeVersion: 24.4.1


### PR DESCRIPTION
## Summary
- bump the nodeVersion to 24.4.1

## Testing
- `npm install`
- `npm start` *(fails: Unknown env config due to missing network access)*

------
https://chatgpt.com/codex/tasks/task_e_6889977b2cbc8325888aee21d09fb1d8