### PR TITLE
Update Alpaca credentials and endpoints

### DIFF
--- a/BullishorBust/Backend/README.md
+++ b/BullishorBust/Backend/README.md
@@ -10,8 +10,9 @@ The server includes CORS support so it can be called from Expo Go.
 1. `npm install`
 2. Create a `.env` file with your Alpaca API credentials:
    ```
-   ALPACA_API_KEY=PKN4ICO3WECXSLDGXCHC
+   ALPACA_API_KEY=AKP4CYCLABN0QHC7GVH4
    ALPACA_SECRET_KEY=PwJAEwLnLnsf7qAVvFutE8VIMgsAgvi7PMkMcCca
-   ALPACA_BASE_URL=https://paper-api.alpaca.markets/v2
+   ALPACA_BASE_URL=https://api.alpaca.markets
+   ALPACA_DATA_URL=https://data.alpaca.markets/v1beta2
    ```
 3. `npm start`

--- a/BullishorBust/Backend/account.js
+++ b/BullishorBust/Backend/account.js
@@ -17,7 +17,7 @@ const headers = {
 
 router.get('/account', async (req, res) => {
   try {
-    const { data } = await axios.get(`${BASE_URL}/account`, { headers });
+    const { data } = await axios.get(`${BASE_URL}/v2/account`, { headers });
     res.json(data);
   } catch (err) {
     console.error('Account fetch failed:', err?.response?.data || err.message);
@@ -28,7 +28,7 @@ router.get('/account', async (req, res) => {
 router.get('/positions/:symbol', async (req, res) => {
   const { symbol } = req.params;
   try {
-    const { data } = await axios.get(`${BASE_URL}/positions/${symbol}`, { headers });
+    const { data } = await axios.get(`${BASE_URL}/v2/positions/${symbol}`, { headers });
     res.json(data);
   } catch (err) {
     console.error('Position fetch failed:', err?.response?.data || err.message);
@@ -39,7 +39,7 @@ router.get('/positions/:symbol', async (req, res) => {
 router.get('/orders', async (req, res) => {
   const query = req.originalUrl.split('?')[1] || '';
   try {
-    const { data } = await axios.get(`${BASE_URL}/orders${query ? '?' + query : ''}`, { headers });
+    const { data } = await axios.get(`${BASE_URL}/v2/orders${query ? '?' + query : ''}`, { headers });
     res.json(data);
   } catch (err) {
     console.error('Orders fetch failed:', err?.response?.data || err.message);
@@ -50,7 +50,7 @@ router.get('/orders', async (req, res) => {
 router.get('/orders/:id', async (req, res) => {
   const { id } = req.params;
   try {
-    const { data } = await axios.get(`${BASE_URL}/orders/${id}`, { headers });
+    const { data } = await axios.get(`${BASE_URL}/v2/orders/${id}`, { headers });
     res.json(data);
   } catch (err) {
     console.error('Order fetch failed:', err?.response?.data || err.message);
@@ -61,7 +61,7 @@ router.get('/orders/:id', async (req, res) => {
 router.delete('/orders/:id', async (req, res) => {
   const { id } = req.params;
   try {
-    const { data } = await axios.delete(`${BASE_URL}/orders/${id}`, { headers });
+    const { data } = await axios.delete(`${BASE_URL}/v2/orders/${id}`, { headers });
     res.json(data);
   } catch (err) {
     console.error('Order delete failed:', err?.response?.data || err.message);
@@ -71,7 +71,7 @@ router.delete('/orders/:id', async (req, res) => {
 
 router.post('/orders', async (req, res) => {
   try {
-    const { data } = await axios.post(`${BASE_URL}/orders`, req.body, { headers });
+    const { data } = await axios.post(`${BASE_URL}/v2/orders`, req.body, { headers });
     res.json(data);
   } catch (err) {
     console.error('Order creation failed:', err?.response?.data || err.message);

--- a/BullishorBust/Backend/index.js
+++ b/BullishorBust/Backend/index.js
@@ -32,11 +32,12 @@ app.get('/ping', (req, res) => {
 // Verify Alpaca API connectivity and credentials
 app.get('/ping-alpaca', async (req, res) => {
   try {
-    await axios.get(`${BASE_URL}/account`, { headers });
-    res.json({ status: 'ok' });
+    const { data } = await axios.get(`${BASE_URL}/v2/account`, { headers });
+    res.json({ account_id: data.id, status: data.status });
   } catch (err) {
-    console.error('Ping Alpaca failed:', err?.response?.data || err.message);
-    res.status(500).json({ error: err.response?.data || err.message });
+    const msg = err.response?.data || err.message;
+    console.error('Ping Alpaca failed:', msg);
+    res.status(err.response?.status || 500).json({ error: msg });
   }
 });
 

--- a/BullishorBust/Backend/trade.js
+++ b/BullishorBust/Backend/trade.js
@@ -1,17 +1,19 @@
+require('dotenv').config();
 const axios = require('axios');
 
-const ALPACA_BASE_URL = 'https://paper-api.alpaca.markets/v2';
-const DATA_URL = 'https://data.alpaca.markets/v1beta2';
-const API_KEY = 'PKN4ICO3WECXSLDGXCHC';
-const SECRET_KEY = 'PwJAEwLnLnsf7qAVvFutE8VIMgsAgvi7PMkMcCca';
+const {
+  ALPACA_API_KEY: API_KEY,
+  ALPACA_SECRET_KEY: SECRET_KEY,
+  ALPACA_BASE_URL: BASE_URL,
+  ALPACA_DATA_URL: DATA_URL,
+} = process.env;
 
 const HEADERS = {
   'APCA-API-KEY-ID': API_KEY,
   'APCA-API-SECRET-KEY': SECRET_KEY,
+  'Content-Type': 'application/json',
 };
 
-
-//require('dotenv').config();
 const express = require('express');
 const router = express.Router();
 
@@ -50,7 +52,7 @@ async function placeLimitBuyThenSell(symbol, qty, limitPrice) {
   let buyOrder;
   try {
     const buyRes = await axios.post(
-      `${ALPACA_BASE_URL}/orders`,
+      `${BASE_URL}/v2/orders`,
       {
         symbol,
         qty,
@@ -73,7 +75,7 @@ async function placeLimitBuyThenSell(symbol, qty, limitPrice) {
   let filledOrder = buyOrder;
   for (let i = 0; i < 20; i++) {
     try {
-      const check = await axios.get(`${ALPACA_BASE_URL}/orders/${buyOrder.id}`, {
+      const check = await axios.get(`${BASE_URL}/v2/orders/${buyOrder.id}`, {
         HEADERS,
       });
       filledOrder = check.;
@@ -96,7 +98,7 @@ async function placeLimitBuyThenSell(symbol, qty, limitPrice) {
   let sellRes;
   try {
     sellRes = await axios.post(
-      `${ALPACA_BASE_URL}/orders`,
+      `${BASE_URL}/v2/orders`,
       {
         symbol,
         qty: parseFloat(filledOrder.filled_qty),
@@ -119,7 +121,7 @@ async function placeLimitBuyThenSell(symbol, qty, limitPrice) {
 async function getLatestPrice(symbol) {
   try {
     const res = await axios.get(
-      `${ALPACA_BASE_URL}/crypto/latest/trades?symbols=${symbol}`,
+      `${DATA_URL}/crypto/latest/trades?symbols=${symbol}`,
       { HEADERS }
     );
     const trade = res..trades && res..trades[symbol];
@@ -134,7 +136,7 @@ async function getLatestPrice(symbol) {
 // Get portfolio value and buying power from the Alpaca account
 async function getAccountInfo() {
   try {
-    const res = await axios.get(`${ALPACA_BASE_URL}/account`, { HEADERS });
+    const res = await axios.get(`${BASE_URL}/v2/account`, { HEADERS });
     const portfolioValue = parseFloat(res.data.portfolio_value);
     const buyingPower = parseFloat(res.data.buying_power);
     const cash = parseFloat(res.data.cash);
@@ -189,7 +191,7 @@ async function placeMarketBuyThenSell(symbol) {
   let buyOrder;
   try {
     const buyRes = await axios.post(
-      `${ALPACA_BASE_URL}/orders`,
+      `${BASE_URL}/v2/orders`,
       {
         symbol,
         qty,
@@ -206,7 +208,7 @@ async function placeMarketBuyThenSell(symbol) {
     await sleep(2000);
     try {
       const buyRes = await axios.post(
-        `${ALPACA_BASE_URL}/orders`,
+        `${BASE_URL}/v2/orders`,
         {
           symbol,
           qty,
@@ -228,7 +230,7 @@ async function placeMarketBuyThenSell(symbol) {
   let filled = buyOrder;
   for (let i = 0; i < 20; i++) {
     try {
-      const chk = await axios.get(`${ALPACA_BASE_URL}/orders/${buyOrder.id}`, {
+      const chk = await axios.get(`${BASE_URL}/v2/orders/${buyOrder.id}`, {
         HEADERS,
       });
       filled = chk.data;
@@ -254,7 +256,7 @@ async function placeMarketBuyThenSell(symbol) {
 
   try {
     const sellRes = await axios.post(
-      `${ALPACA_BASE_URL}/orders`,
+      `${BASE_URL}/v2/orders`,
       {
         symbol,
         qty: parseFloat(filled.filled_qty),
@@ -288,7 +290,7 @@ router.post('/buy', async (req, res) => {
   const { symbol, qty, side, type, time_in_force, limit_price } = req.body;
   const order = { symbol, qty, side, type, time_in_force, limit_price };
   try {
-    const response = await axios.post(`${ALPACA_BASE_URL}/orders`, order, { HEADERS });
+    const response = await axios.post(`${BASE_URL}/v2/orders`, order, { HEADERS });
     res.json(response.data);
   } catch (error) {
     console.error('Buy error:', error?.response?.data || error.message);
@@ -299,7 +301,7 @@ router.post('/buy', async (req, res) => {
   console.log('Attempting to place market buy for', symbol);
   try {
     const buyOrder = await axios.post(
-      `${ALPACA_BASE_URL}/orders`,
+      `${BASE_URL}/v2/orders`,
       {
         symbol,
         qty,
@@ -317,7 +319,7 @@ router.post('/buy', async (req, res) => {
 
     console.log('Attempting to place market sell for', symbol);
     const sellOrder = await axios.post(
-      `${ALPACA_BASE_URL}/orders`,
+      `${BASE_URL}/v2/orders`,
       {
         symbol,
         qty,

--- a/BullishorBust/Frontend/App.js
+++ b/BullishorBust/Frontend/App.js
@@ -34,15 +34,20 @@ import {
 *    for production use.
 */
 
-// API credentials are expected to be provided via environment variables.
-// If they are missing the app will still run but trading requests will fail.
-// Alpaca base URL remains the paper trading endpoint.
-const ALPACA_BASE_URL = 'https://paper-api.alpaca.markets/v2';
+import Constants from 'expo-constants';
 
-// Helper to build Alpaca auth headers from Expo environment variables
+// API credentials are provided via Expo config extras.
+const {
+  ALPACA_API_KEY,
+  ALPACA_SECRET_KEY,
+  ALPACA_BASE_URL,
+  ALPACA_DATA_URL,
+} = Constants.expoConfig.extra || {};
+
+// Helper to build Alpaca auth headers from Expo config
 const getAlpacaHeaders = () => ({
-  'APCA-API-KEY-ID': process.env.EXPO_PUBLIC_ALPACA_KEY,
-  'APCA-API-SECRET-KEY': process.env.EXPO_PUBLIC_ALPACA_SECRET,
+  'APCA-API-KEY-ID': ALPACA_API_KEY,
+  'APCA-API-SECRET-KEY': ALPACA_SECRET_KEY,
   'Content-Type': 'application/json',
 });
 

--- a/BullishorBust/Frontend/app.json
+++ b/BullishorBust/Frontend/app.json
@@ -1,0 +1,12 @@
+{
+  "expo": {
+    "name": "bullish-or-bust",
+    "version": "1.0.0",
+    "extra": {
+      "ALPACA_API_KEY": "AKP4CYCLABN0QHC7GVH4",
+      "ALPACA_SECRET_KEY": "PwJAEwLnLnsf7qAVvFutE8VIMgsAgvi7PMkMcCca",
+      "ALPACA_BASE_URL": "https://api.alpaca.markets",
+      "ALPACA_DATA_URL": "https://data.alpaca.markets/v1beta2"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- use dotenv env vars for Alpaca credentials in trade.js
- add ping-alpaca account check
- update account routes for v2 endpoints
- load Alpaca keys via expo constants in frontend
- document new env vars and add expo app.json

## Testing
- `node network.test.js` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_688d05da012c83259a1b5421256c7051