### PR TITLE
Fix const initializer bug in App.js

### DIFF
--- a/BullishorBust/Frontend/App.js
+++ b/BullishorBust/Frontend/App.js
@@ -363,6 +363,9 @@ export default function App() {
       }
       const priceData = await pRes.json();
       const histoData = await hRes.json();
+      if (!priceData?.USD || !histoData?.Data) {
+        throw new Error('Malformed response from CryptoCompare');
+      }
     } catch (err) {
       console.warn('Signal validation error:', err);
     }


### PR DESCRIPTION
## Summary
- handle malformed CryptoCompare responses so the component doesn't fail

## Testing
- `node network.test.js` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_688d159c37448325a1724cfe5ee845fb