### PR TITLE
Align env files with examples

### DIFF
--- a/BullishorBust/Backend/.env
+++ b/BullishorBust/Backend/.env
@@ -1,4 +1,4 @@
-ALPACA_API_KEY=AKP4CYCLABN0QHC7GVH4
-ALPACA_SECRET_KEY=PwJAEwLnLnsf7qAVvFutE8VIMgsAgvi7PMkMcCca
-ALPACA_BASE_URL=https://api.alpaca.markets
+ALPACA_API_KEY=demo-key
+ALPACA_SECRET_KEY=demo-secret
+ALPACA_BASE_URL=https://paper-api.alpaca.markets
 ALPACA_DATA_URL=https://data.alpaca.markets/v1beta2

--- a/BullishorBust/Backend/env.example
+++ b/BullishorBust/Backend/env.example
@@ -1,4 +1,7 @@
-ALPACA_API_KEY=AKP4CYCLABN0QHC7GVH4
-ALPACA_SECRET_KEY=PwJAEwLnLnsf7qAVvFutE8VIMgsAgvi7PMkMcCca
-ALPACA_BASE_URL=https://api.alpaca.markets
+# Example Alpaca credentials used by the backend.
+# Replace these with your real credentials or export them
+# in the environment when running locally.
+ALPACA_API_KEY=demo-key
+ALPACA_SECRET_KEY=demo-secret
+ALPACA_BASE_URL=https://paper-api.alpaca.markets
 ALPACA_DATA_URL=https://data.alpaca.markets/v1beta2

--- a/BullishorBust/Frontend/.env
+++ b/BullishorBust/Frontend/.env
@@ -1,4 +1,4 @@
-ALPACA_API_KEY=AKP4CYCLABN0QHC7GVH4
-ALPACA_SECRET_KEY=PwJAEwLnLnsf7qAVvFutE8VIMgsAgvi7PMkMcCca
-ALPACA_BASE_URL=https://api.alpaca.markets
+ALPACA_API_KEY=demo-key
+ALPACA_SECRET_KEY=demo-secret
+ALPACA_BASE_URL=https://paper-api.alpaca.markets
 ALPACA_DATA_URL=https://data.alpaca.markets/v1beta2

--- a/BullishorBust/Frontend/.env.example
+++ b/BullishorBust/Frontend/.env.example
@@ -1,4 +1,5 @@
-ALPACA_API_KEY=AKP4CYCLABN0QHC7GVH4
-ALPACA_SECRET_KEY=PwJAEwLnLnsf7qAVvFutE8VIMgsAgvi7PMkMcCca
-ALPACA_BASE_URL=https://api.alpaca.markets
+# Example Alpaca credentials used by the Expo app
+ALPACA_API_KEY=demo-key
+ALPACA_SECRET_KEY=demo-secret
+ALPACA_BASE_URL=https://paper-api.alpaca.markets
 ALPACA_DATA_URL=https://data.alpaca.markets/v1beta2


### PR DESCRIPTION
## Summary
- remove real keys from envs and document example defaults

## Testing
- `npm install` in Backend
- `npm install` in Frontend
- `node index.js` then `node network.test.js`
- `npx expo start` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688d1890b7988325a15b0852b7ebbe58