### PR TITLE
Fix config and add status endpoint

### DIFF
--- a/BullishorBust/Backend/index.js
+++ b/BullishorBust/Backend/index.js
@@ -7,7 +7,7 @@ const { router: accountRouter } = require('./account');
 const app = express();
 app.use(express.json());
 
-app.use(cors());
+app.use(cors({ origin: '*' }));
 app.use('/api', tradeRouter);
 app.use('/api', accountRouter);
 const {
@@ -38,6 +38,16 @@ app.get('/ping-alpaca', async (req, res) => {
     const msg = err.response?.data || err.message;
     console.error('Ping Alpaca failed:', msg);
     res.status(err.response?.status || 500).json({ error: msg });
+  }
+});
+
+// Expose API status endpoint for frontend validation
+app.get('/api/status', async (req, res) => {
+  try {
+    const account = await axios.get(`${BASE_URL}/v2/account`, { headers });
+    res.json({ account: account.data });
+  } catch (err) {
+    res.status(500).json({ error: 'Alpaca credentials invalid' });
   }
 });
 

--- a/BullishorBust/Frontend/App.js
+++ b/BullishorBust/Frontend/App.js
@@ -35,6 +35,7 @@ import {
 */
 
 import Constants from 'expo-constants';
+import { BACKEND_BASE_URL } from './constants';
 
 // API credentials are provided via Expo config extras.
 const {
@@ -56,7 +57,7 @@ const getAlpacaHeaders = () => ({
 // When running on a real device "localhost" will not resolve to your
 // development machine. Use an Expo or ngrok tunnel URL instead.
 // Backend server for trade requests
-const BACKEND_URL = 'https://borb4.onrender.com';
+const BACKEND_URL = BACKEND_BASE_URL;
 
 // Crypto orders require GTC time in force
 const CRYPTO_TIME_IN_FORCE = 'gtc';
@@ -277,6 +278,7 @@ export default function App() {
       };
     } catch (err) {
       console.error('getPositionInfo error:', err);
+      Alert.alert('Network Error', 'Could not reach backend.');
       return null;
     }
   };
@@ -299,6 +301,7 @@ export default function App() {
       return Array.isArray(data) ? data : [];
     } catch (err) {
       console.error('getOpenOrders error:', err);
+      Alert.alert('Network Error', 'Could not reach backend.');
       return [];
     }
   };
@@ -334,6 +337,7 @@ export default function App() {
       }
     } catch (err) {
       logTradeAction('forced_exit_error', symbol, { error: err.message });
+      Alert.alert('Network Error', 'Could not reach backend.');
     }
   };
 
@@ -350,6 +354,7 @@ export default function App() {
       }
     } catch (err) {
       // if check fails just exit
+      Alert.alert('Network Error', 'Could not reach backend.');
       return;
     }
 
@@ -368,6 +373,7 @@ export default function App() {
       }
     } catch (err) {
       console.warn('Signal validation error:', err);
+      Alert.alert('Network Error', 'Could not reach backend.');
     }
   };
 

--- a/BullishorBust/Frontend/constants.js
+++ b/BullishorBust/Frontend/constants.js
@@ -1,0 +1,1 @@
+export const BACKEND_BASE_URL = "https://your-backend-app.onrender.com/api"; // replace with actual Render domain


### PR DESCRIPTION
## Summary
- add constants.js with backend URL
- reference constant for fetch calls
- display network alerts on errors
- allow all CORS origins and expose `/api/status`

## Testing
- `npm install` in `BullishorBust/Backend`
- `npm install` in `BullishorBust/Frontend`

------
https://chatgpt.com/codex/tasks/task_e_688d1e174fb483258b14ec7a96e7c5bc