### PR TITLE
Fix env var loading for frontend and backend

### DIFF
--- a/BullishorBust/Backend/index.js
+++ b/BullishorBust/Backend/index.js
@@ -1,4 +1,5 @@
-require('dotenv').config();
+// Load environment variables from the Backend/.env file
+require('dotenv').config({ path: __dirname + '/.env' });
 const express = require('express');
 const cors = require('cors');
 const axios = require('axios');

--- a/BullishorBust/Backend/trade.js
+++ b/BullishorBust/Backend/trade.js
@@ -1,4 +1,5 @@
-require('dotenv').config();
+// Load environment variables from the Backend/.env file
+require('dotenv').config({ path: __dirname + '/.env' });
 const axios = require('axios');
 const express = require('express');
 const router = express.Router();

--- a/BullishorBust/Frontend/App.js
+++ b/BullishorBust/Frontend/App.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import Constants from 'expo-constants';
 import {
   View,
   Text,
@@ -37,12 +38,20 @@ import {
 // API credentials are expected to be provided via environment variables.
 // If they are missing the app will still run but trading requests will fail.
 // Alpaca base URL remains the paper trading endpoint.
-const ALPACA_BASE_URL = 'https://paper-api.alpaca.markets/v2';
+const {
+  EXPO_PUBLIC_ALPACA_KEY,
+  EXPO_PUBLIC_ALPACA_SECRET,
+  EXPO_PUBLIC_BACKEND_URL,
+  EXPO_PUBLIC_ALPACA_BASE_URL,
+} = Constants.expoConfig?.extra || {};
+
+const ALPACA_BASE_URL = EXPO_PUBLIC_ALPACA_BASE_URL ||
+  'https://paper-api.alpaca.markets/v2';
 
 // Helper to build Alpaca auth headers from Expo environment variables
 const getAlpacaHeaders = () => ({
-  'APCA-API-KEY-ID': process.env.EXPO_PUBLIC_ALPACA_KEY,
-  'APCA-API-SECRET-KEY': process.env.EXPO_PUBLIC_ALPACA_SECRET,
+  'APCA-API-KEY-ID': EXPO_PUBLIC_ALPACA_KEY,
+  'APCA-API-SECRET-KEY': EXPO_PUBLIC_ALPACA_SECRET,
   'Content-Type': 'application/json',
 });
 
@@ -51,7 +60,7 @@ const getAlpacaHeaders = () => ({
 // When running on a real device "localhost" will not resolve to your
 // development machine. Use an Expo or ngrok tunnel URL instead.
 // Backend server for trade requests
-const BACKEND_URL = 'https://borb4.onrender.com';
+const BACKEND_URL = EXPO_PUBLIC_BACKEND_URL || 'https://borb4.onrender.com';
 
 // Crypto orders require GTC time in force
 const CRYPTO_TIME_IN_FORCE = 'gtc';

--- a/BullishorBust/Frontend/app.config.js
+++ b/BullishorBust/Frontend/app.config.js
@@ -1,0 +1,13 @@
+import 'dotenv/config';
+
+export default ({ config }) => ({
+  ...config,
+  extra: {
+    ...config.extra,
+    EXPO_PUBLIC_ALPACA_KEY: process.env.ALPACA_API_KEY,
+    EXPO_PUBLIC_ALPACA_SECRET: process.env.ALPACA_SECRET_KEY,
+    EXPO_PUBLIC_ALPACA_BASE_URL: process.env.ALPACA_BASE_URL,
+    EXPO_PUBLIC_ALPACA_DATA_URL: process.env.ALPACA_DATA_URL,
+    EXPO_PUBLIC_BACKEND_URL: process.env.EXPO_PUBLIC_BACKEND_URL,
+  },
+});


### PR DESCRIPTION
## Summary
- load backend env vars with explicit .env path
- expose frontend env vars to Expo via app.config.js
- read Expo env vars from Constants in App.js

## Testing
- `node network.test.js` *(fails: Cannot read properties of undefined (reading 'env'))*

------
https://chatgpt.com/codex/tasks/task_e_688d527bd6cc8325aa1b1cc0c6bc896d