### PR TITLE
Use env backend url fallback

### DIFF
--- a/BullishorBust/Frontend/App.js
+++ b/BullishorBust/Frontend/App.js
@@ -66,7 +66,7 @@ const getAlpacaHeaders = () => ({
 // When running on a real device "localhost" will not resolve to your
 // development machine. Use an Expo or ngrok tunnel URL instead.
 // Backend server for trade requests
-const BACKEND_URL = ALPACA_BASE_URL || 'https://borb4.onrender.com';
+const BACKEND_URL = EXPO_PUBLIC_BACKEND_URL || 'https://borb4.onrender.com';
 
 // Crypto orders require GTC time in force
 const CRYPTO_TIME_IN_FORCE = 'gtc';


### PR DESCRIPTION
## Summary
- use `EXPO_PUBLIC_BACKEND_URL` with fallback to Render backend URL

## Testing
- `npm test` *(fails: Missing script "test")*
- `node network.test.js` *(fails: process.frontend.env is undefined)*

------
https://chatgpt.com/codex/tasks/task_e_688e69b3bebc832580f78f3c9b5cef87