### PR TITLE
Configure live Alpaca endpoints

### DIFF
--- a/BullishorBust/Backend/trade.js
+++ b/BullishorBust/Backend/trade.js
@@ -285,4 +285,5 @@ module.exports = {
   router,
   placeLimitBuyThenSell,
   placeMarketBuyThenSell,
+  getAccountInfo,
 };

--- a/BullishorBust/Frontend/.env
+++ b/BullishorBust/Frontend/.env
@@ -1,4 +1,5 @@
-ALPACA_API_KEY=PKN4ICO3WECXSLDGXCHC
+EXPO_PUBLIC_BACKEND_URL=https://borb4.onrender.com
+ALPACA_API_KEY=AKP4CYCLABN0QHC7GVH4
 ALPACA_SECRET_KEY=PwJAEwLnLnsf7qAVvFutE8VIMgsAgvi7PMkMcCca
-ALPACA_BASE_URL=https://paper-api.alpaca.markets
+ALPACA_BASE_URL=https://api.alpaca.markets
 ALPACA_DATA_URL=https://data.alpaca.markets/v1beta2

--- a/BullishorBust/Frontend/.env.example
+++ b/BullishorBust/Frontend/.env.example
@@ -1,5 +1,6 @@
 # Example Alpaca credentials used by the Expo app
-ALPACA_API_KEY=PKN4ICO3WECXSLDGXCHC
-ALPACA_SECRET_KEY=demo-secret
-ALPACA_BASE_URL=https://paper-api.alpaca.markets
+EXPO_PUBLIC_BACKEND_URL=https://borb4.onrender.com
+ALPACA_API_KEY=AKP4CYCLABN0QHC7GVH4
+ALPACA_SECRET_KEY=PwJAEwLnLnsf7qAVvFutE8VIMgsAgvi7PMkMcCca
+ALPACA_BASE_URL=https://api.alpaca.markets
 ALPACA_DATA_URL=https://data.alpaca.markets/v1beta2

--- a/BullishorBust/Frontend/constants.js
+++ b/BullishorBust/Frontend/constants.js
@@ -1,2 +1,2 @@
-export const BACKEND_BASE_URL = "https://paper-api.alpaca.markets/v2"; // replace with actual Render domain
+export const BACKEND_BASE_URL = "https://api.alpaca.markets/v2"; // replace with actual Render domain
 export default { BACKEND_BASE_URL };

--- a/BullishorBust/Frontend/package.json
+++ b/BullishorBust/Frontend/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "axios": "^1.6.8",
     "expo": "~50.0.0",
+    "expo-constants": "^14.0.0",
     "react": "18.2.0",
     "react-native": "0.72.3",
     "react-native-root-toast": "^3.4.0"


### PR DESCRIPTION
## Summary
- add expo-constants dependency and wire Expo to live backend URL
- switch example env files and constants to live Alpaca API
- export getAccountInfo so backend account route works with env-based base URL

## Testing
- `npm install` *(frontend, failed: 403 Forbidden fetching expo-constants)*
- `npm install` *(backend, success)*
- `curl https://api.alpaca.markets/v2/account` *(failed: network unreachable)*
- `curl https://borb4.onrender.com/api/account` *(failed: network unreachable)*
- `curl http://localhost:3000/api/account` *(500: Request failed with status code 403)*
- `npx expo start --non-interactive` *(failed: Forbidden during dependency check)*

------
https://chatgpt.com/codex/tasks/task_e_688e722d6b548325920b972fc7c7aece