### PR TITLE
fix alpaca headers and base url

### DIFF
--- a/BullishorBust/Backend/index.js
+++ b/BullishorBust/Backend/index.js
@@ -18,7 +18,10 @@ const {
   ALPACA_DATA_URL: DATA_URL = 'https://data.alpaca.markets/v1beta2',
 } = process.env;
 
-const headers = {
+// Standard Alpaca auth headers used for every API call. Keeping them in a
+// single constant avoids accidentally omitting a required header on some
+// requests which would result in mysterious `AccessDenied` errors.
+const HEADERS = {
   'APCA-API-KEY-ID': API_KEY,
   'APCA-API-SECRET-KEY': SECRET_KEY,
   'Content-Type': 'application/json',
@@ -33,7 +36,10 @@ app.get('/ping', (req, res) => {
 // Verify Alpaca API connectivity and credentials
 app.get('/ping-alpaca', async (req, res) => {
   try {
-    const { data } = await axios.get(`${BASE_URL}/v2/account`, { headers });
+    // Always pass headers via the `headers` key so axios sends them correctly.
+    const { data } = await axios.get(`${BASE_URL}/v2/account`, {
+      headers: HEADERS,
+    });
     res.json({ account_id: data.id, status: data.status });
   } catch (err) {
     const msg = err.response?.data || err.message;
@@ -45,7 +51,9 @@ app.get('/ping-alpaca', async (req, res) => {
 // Expose API status endpoint for frontend validation
 app.get('/api/status', async (req, res) => {
   try {
-    const account = await axios.get(`${BASE_URL}/v2/account`, { headers });
+    const account = await axios.get(`${BASE_URL}/v2/account`, {
+      headers: HEADERS,
+    });
     res.json({ account: account.data });
   } catch (err) {
     res.status(500).json({ error: 'Alpaca credentials invalid' });

--- a/BullishorBust/Backend/trade.js
+++ b/BullishorBust/Backend/trade.js
@@ -11,6 +11,8 @@ const {
   ALPACA_DATA_URL: DATA_URL,
 } = process.env;
 
+// Standard headers required by Alpaca. Keeping them in a single constant
+// ensures every request sends the proper authentication and content type.
 const HEADERS = {
   'APCA-API-KEY-ID': API_KEY,
   'APCA-API-SECRET-KEY': SECRET_KEY,
@@ -44,7 +46,7 @@ async function placeLimitBuyThenSell(symbol, qty, limitPrice) {
         time_in_force: 'gtc', // crypto orders must be GTC
         limit_price: parseFloat(limitPrice),
       },
-      { HEADERS }
+      { headers: HEADERS }
     );
     console.log('Buy order response:', buyRes.data);
     buyOrder = buyRes.data;
@@ -59,7 +61,7 @@ async function placeLimitBuyThenSell(symbol, qty, limitPrice) {
   for (let i = 0; i < 20; i++) {
     try {
       const check = await axios.get(`${BASE_URL}/v2/orders/${buyOrder.id}`, {
-        HEADERS,
+        headers: HEADERS,
       });
       filledOrder = check.data;
       if (filledOrder.status === 'filled') break;
@@ -90,7 +92,7 @@ async function placeLimitBuyThenSell(symbol, qty, limitPrice) {
         time_in_force: 'gtc', // match the buy order's time in force
         limit_price: parseFloat(sellPrice),
       },
-      { HEADERS }
+      { headers: HEADERS }
     );
   } catch (err) {
     console.error('Sell order failed:', err?.response?.data || err.message);
@@ -105,7 +107,7 @@ async function getLatestPrice(symbol) {
   try {
     const res = await axios.get(
       `${DATA_URL}/crypto/latest/trades?symbols=${symbol}`,
-      { HEADERS }
+      { headers: HEADERS }
     );
     const trade = res.data.trades && res.data.trades[symbol];
     if (!trade) throw new Error(`Price not available for ${symbol}`);
@@ -119,7 +121,9 @@ async function getLatestPrice(symbol) {
 // Get portfolio value and buying power from the Alpaca account
 async function getAccountInfo() {
   try {
-    const res = await axios.get(`${BASE_URL}/v2/account`, { HEADERS });
+    const res = await axios.get(`${BASE_URL}/v2/account`, {
+      headers: HEADERS,
+    });
     const portfolioValue = parseFloat(res.data.portfolio_value);
     const buyingPower = parseFloat(res.data.buying_power);
     const cash = parseFloat(res.data.cash);
@@ -182,7 +186,7 @@ async function placeMarketBuyThenSell(symbol) {
         type: 'market',
         time_in_force: 'gtc',
       },
-      { HEADERS }
+      { headers: HEADERS }
     );
     console.log('Buy order response:', buyRes.data);
     buyOrder = buyRes.data;
@@ -199,7 +203,7 @@ async function placeMarketBuyThenSell(symbol) {
           type: 'market',
           time_in_force: 'gtc',
         },
-        { HEADERS }
+        { headers: HEADERS }
       );
       console.log('Buy order retry response:', buyRes.data);
       buyOrder = buyRes.data;
@@ -214,7 +218,7 @@ async function placeMarketBuyThenSell(symbol) {
   for (let i = 0; i < 20; i++) {
     try {
       const chk = await axios.get(`${BASE_URL}/v2/orders/${buyOrder.id}`, {
-        HEADERS,
+        headers: HEADERS,
       });
       filled = chk.data;
       if (filled.status === 'filled') break;
@@ -248,7 +252,7 @@ async function placeMarketBuyThenSell(symbol) {
         time_in_force: 'gtc',
         limit_price: parseFloat(limitPrice),
       },
-      { HEADERS }
+      { headers: HEADERS }
     );
     return { buy: filled, sell: sellRes.data };
   } catch (err) {
@@ -273,7 +277,9 @@ router.post('/buy', async (req, res) => {
   const { symbol, qty, side, type, time_in_force, limit_price } = req.body;
   const order = { symbol, qty, side, type, time_in_force, limit_price };
   try {
-    const response = await axios.post(`${BASE_URL}/v2/orders`, order, { HEADERS });
+    const response = await axios.post(`${BASE_URL}/v2/orders`, order, {
+      headers: HEADERS,
+    });
     res.json(response.data);
   } catch (error) {
     console.error('Buy error:', error?.response?.data || error.message);

--- a/BullishorBust/Frontend/constants.js
+++ b/BullishorBust/Frontend/constants.js
@@ -1,2 +1,0 @@
-export const BACKEND_BASE_URL = "https://api.alpaca.markets/v2"; // replace with actual Render domain
-export default { BACKEND_BASE_URL };

--- a/network.test.js
+++ b/network.test.js
@@ -1,4 +1,7 @@
-const BASE_URL = process.frontend.env.ALPACA_BASE_URL || 'http://localhost:3000';
+// Default to the live Alpaca endpoint if no environment variable is set.
+// Using the correct base URL avoids accidental requests to localhost which
+// would obviously fail the connectivity test.
+const BASE_URL = process.env.ALPACA_BASE_URL || 'https://api.alpaca.markets';
 (async () => {
   try {
     const ping = await fetch(`${BASE_URL}/ping`);


### PR DESCRIPTION
## Summary
- ensure Alpaca requests always include auth headers via `headers: HEADERS`
- document and fix base URL usage, remove unused constants file
- update network test to default to live Alpaca endpoint

## Testing
- `curl -s http://localhost:3000/ping`
- `curl -s http://localhost:3000/api/status`
- `curl -i -H "APCA-API-KEY-ID: ****" -H "APCA-API-SECRET-KEY: ****" https://api.alpaca.markets/v2/account` *(fails: CONNECT tunnel failed, response 403)*
- `curl -i -X POST -H "APCA-API-KEY-ID: ****" -H "APCA-API-SECRET-KEY: ****" -H "Content-Type: application/json" -d '{"symbol":"BTC/USD","qty":1,"side":"buy","type":"market","time_in_force":"gtc"}' https://api.alpaca.markets/v2/orders` *(fails: CONNECT tunnel failed, response 403)*
- `CI=1 npm start` *(fails: SyntaxError: Unexpected token 'F', "Forbidden" is not valid JSON)*


------
https://chatgpt.com/codex/tasks/task_e_688e759b228883258ea1ded2dcf2784a